### PR TITLE
Implement cmd-line support for an OutputDirectory argument

### DIFF
--- a/RoslynPluginGenerator/CommandLine/ArgumentProcessor.cs
+++ b/RoslynPluginGenerator/CommandLine/ArgumentProcessor.cs
@@ -41,7 +41,8 @@ namespace SonarQube.Plugins.Roslyn.CommandLine
             public const string SqaleXmlFile = "sqale.xml";
             public const string AcceptLicenses = "accept.licenses";
             public const string RecurseDependencies = "recurse.dependencies";
-        }
+            public const string OutputDirectory = "dir.output";
+    }
 
         private static IList<ArgumentDescriptor> Descriptors;
 
@@ -59,6 +60,8 @@ namespace SonarQube.Plugins.Roslyn.CommandLine
                 id: KeywordIds.AcceptLicenses, prefixes: new string[] { "/acceptLicenses" }, required: false, allowMultiple: false, description: CmdLineResources.ArgDescription_AcceptLicenses, isVerb: true));
             Descriptors.Add(new ArgumentDescriptor(
                 id: KeywordIds.RecurseDependencies, prefixes: new string[] { "/recurse" }, required: false, allowMultiple: false, description: CmdLineResources.ArgDescription_RecurseDependencies, isVerb: true));
+            Descriptors.Add(new ArgumentDescriptor(
+                id: KeywordIds.OutputDirectory, prefixes: new string[] { "/output:", "/o:" }, required: false, allowMultiple: false, description: CmdLineResources.ArgDescription_OutputDir));
 
             Debug.Assert(Descriptors.All(d => d.Prefixes != null && d.Prefixes.Any()), "All descriptors must provide at least one prefix");
             Debug.Assert(Descriptors.Select(d => d.Id).Distinct().Count() == Descriptors.Count, "All descriptors must have a unique id");
@@ -121,6 +124,7 @@ namespace SonarQube.Plugins.Roslyn.CommandLine
 
             bool acceptLicense = GetLicenseAcceptance(arguments);
             bool recurseDependencies = GetRecursion(arguments);
+            var outputDir = GetOutputDirectory(arguments);
 
             if (parsedOk)
             {
@@ -132,7 +136,7 @@ namespace SonarQube.Plugins.Roslyn.CommandLine
                     sqaleFilePath,
                     acceptLicense,
                     recurseDependencies,
-                    System.IO.Directory.GetCurrentDirectory());
+                    outputDir ?? System.IO.Directory.GetCurrentDirectory());
             }
 
             return processed;
@@ -219,6 +223,12 @@ namespace SonarQube.Plugins.Roslyn.CommandLine
             ArgumentInstance arg = arguments.SingleOrDefault(a => ArgumentDescriptor.IdComparer.Equals(KeywordIds.RecurseDependencies, a.Descriptor.Id));
             return arg != null;
         }
+
+        private static string GetOutputDirectory(IEnumerable<ArgumentInstance> arguments)
+        {
+          ArgumentInstance arg = arguments.SingleOrDefault(a => ArgumentDescriptor.IdComparer.Equals(KeywordIds.OutputDirectory, a.Descriptor.Id));
+          return arg?.Value;
+         }
 
     }
 }

--- a/RoslynPluginGenerator/CommandLine/CmdLineResources.Designer.cs
+++ b/RoslynPluginGenerator/CommandLine/CmdLineResources.Designer.cs
@@ -19,7 +19,7 @@ namespace SonarQube.Plugins.Roslyn.CommandLine {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class CmdLineResources {
@@ -75,6 +75,15 @@ namespace SonarQube.Plugins.Roslyn.CommandLine {
         internal static string ArgDescription_AnalzyerRef {
             get {
                 return ResourceManager.GetString("ArgDescription_AnalzyerRef", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to /output:[Plugin Output Dir] or /o:[Plugin Output Dir].
+        /// </summary>
+        internal static string ArgDescription_OutputDir {
+            get {
+                return ResourceManager.GetString("ArgDescription_OutputDir", resourceCulture);
             }
         }
         

--- a/RoslynPluginGenerator/CommandLine/CmdLineResources.resx
+++ b/RoslynPluginGenerator/CommandLine/CmdLineResources.resx
@@ -123,6 +123,9 @@
   <data name="ArgDescription_AnalzyerRef" xml:space="preserve">
     <value>/a:[NuGet package id]  or  /a:[NuGet package id]:[version]</value>
   </data>
+  <data name="ArgDescription_OutputDir" xml:space="preserve">
+    <value>/output:[Plugin Output Dir] or /o:[Plugin Output Dir]</value>
+  </data>
   <data name="ArgDescription_RecurseDependencies" xml:space="preserve">
     <value>/recurse - search for analyzers in target package and any dependencies</value>
   </data>


### PR DESCRIPTION
In order to properly use the `PluginGenerator` in a build pipeline, it is very useful to be able to define the output directory as a command line argument.

I've implemented the support for this as follows:
`/output:[OutputDir]` and `/o:[OutputDir]`